### PR TITLE
Added Z-index for container to allow Download Link to be clickable

### DIFF
--- a/src/scss/components/_editor.scss
+++ b/src/scss/components/_editor.scss
@@ -76,6 +76,7 @@
   position: absolute;
   bottom: 10px;
   right: 10px;
+  z-indez: 3;
 }
 .subscription-result__actions {
   display: flex;

--- a/src/scss/components/_editor.scss
+++ b/src/scss/components/_editor.scss
@@ -76,7 +76,7 @@
   position: absolute;
   bottom: 10px;
   right: 10px;
-  z-indez: 3;
+  z-index: 3;
 }
 .subscription-result__actions {
   display: flex;


### PR DESCRIPTION
### Fixes #241 

...

### Checks

- [ ] Ran `npm run test-build`

### Changes proposed in this pull request:

- Added a z-index of the query-result__bottom-actions div, set to 3 
- 
- 
