### PR TITLE
fix: pin @types/node to 10.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@types/electron": "^1.4.38",
     "@types/jasmine": "2.8.8",
     "@types/mousetrap": "^1.6.0",
-    "@types/node": "^10.5.2",
+    "@types/node": "10.11.0",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.24.1",


### PR DESCRIPTION
### Fixes #

...

### Checks

- [ ] Ran `npm run test-build`

### Changes proposed in this pull request:

- 
- 
- 
