### PR TITLE
Fix brew cask install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There are apps for [mac, windows and linux users](https://altair.sirmuel.design/
 You can also install using cask:
 
 ```
-$ brew cask install altair
+$ brew cask install altair-graphql-client
 ```
 
 For linux users, you can also install using [snap](https://snapcraft.io/altair):

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,7 +26,7 @@ releases:
     image: osx_logo.svg
     unique_term: dmg
     link: https://github.com/imolorhe/altair/releases/latest
-    extra: brew cask install altair
+    extra: brew cask install altair-graphql-client
   -
     name: linux
     image: linux_logo.svg


### PR DESCRIPTION
### Fixes 

Update the `brew cask` installation command to use the correct name, `altair-graphql-client`. See https://github.com/Homebrew/homebrew-cask/blob/master/Casks/altair-graphql-client.rb.

### Checks

- [x] Ran `bundle exec jekyll build` without any complaints

### Changes proposed in this pull request:

 - Update installation comand