### PR TITLE
fix: pin mime-types to 2.1.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "karma-jasmine": "^2.0.1",
     "karma-jasmine-html-reporter": "1.3.1",
     "lerna": "^3.10.7",
-    "mime-types": "^2.1.17",
+    "mime-types": "2.1.22",
     "mocha": "6.1.3",
     "ncp": "^2.0.0",
     "ngrx-store-freeze": "^0.2.0",


### PR DESCRIPTION
### Fixes #

...

### Checks

- [ ] Ran `npm run test-build`

### Changes proposed in this pull request:

- 
- 
- 
