### PR TITLE
Set correct header for js response

### DIFF
--- a/packages/altair-express-middleware/index.ts
+++ b/packages/altair-express-middleware/index.ts
@@ -15,6 +15,7 @@ export const altairExpress = (opts: RenderOptions): express.Express => {
     return res.send(renderAltair(opts));
   });
   app.get('/initial_options.js', (req, res) => {
+    res.set('Content-Type', 'text/javascript');
     return res.send(renderInitialOptions(opts));
   });
   app.use(express.static(getDistDirectory()));


### PR DESCRIPTION
### Fixes #
Sets the correct content-type for the javascript response in initial options