### PR TITLE
Update CONTRIBUTING.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ To get more help on working with the project, check out the [Angular CLI README]
 
 ### Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
+This project exists thanks to all the people who contribute. [[Contribute](.github/CONTRIBUTING.md)].
 <a href="graphs/contributors"><img src="https://opencollective.com/altair/contributors.svg?width=890" /></a>
 
 ## Backers


### PR DESCRIPTION
The `CONTRIBUTING.md` was moved to `.github`  in change commit 96d7d1c271afce3d91b82f620d89e060ac5f7876 but the `README` wasn't updated
Correcting this to make life better for anyone going to the `README` in order to find that document

### Fixes #

No issue 

### Checks

- N/A

### Changes proposed in this pull request:

- Add correct path for `CONTRIBUTING.md`
