### PR TITLE
Only add query params for GET requests if not empty

### DIFF
--- a/src/app/services/gql/gql.service.ts
+++ b/src/app/services/gql/gql.service.ts
@@ -212,7 +212,7 @@ export class GqlService {
   getParamsFromData(data) {
     return Object.keys(data)
       .reduce(
-        (params, key) => params.set(key, typeof data[key] === 'object' ? JSON.stringify(data[key]) : data[key]),
+        (params, key) => data[key] ? params.set(key, typeof data[key] === 'object' ? JSON.stringify(data[key]) : data[key]) : params,
         new HttpParams()
       );
   }


### PR DESCRIPTION
### Fixes #

When serializing params for GET-based GraphQL calls, `null` is cast to a string for at least `operationName`, which causes certain GraphQL libraries to have issues. Since query parameters for GET requests can't cleanly convey a null value, when serializing the parameters to perform a GET request, it makes sense to me to not include empty params at all.

### Checks

- [x] Ran `npm run test-build`

### Changes proposed in this pull request:

- When sending GraphQL GET requests, only include params if they contain data, as the values are otherwise incorrectly cast to strings.
