### PR TITLE
Add support for setting initial environments

### DIFF
--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -1,10 +1,10 @@
 import isElectron from './utils/is_electron';
 import { IDictionary } from './interfaces/shared';
+import { State as IInitialEnvironments } from './reducers/environments';
 
 const isTranslateMode = (window as any).__ALTAIR_TRANSLATE__;
 
 export interface AltairConfigOptions {
-
   /**
    * URL to set as the server endpoint
    */
@@ -38,6 +38,24 @@ export interface AltairConfigOptions {
    * }
    */
   initialHeaders?: IDictionary;
+
+  /**
+   * Initial Environments to be added
+   * @example
+   * {
+   *   base: {
+   *     title: 'Environment',
+   *     variablesJson: '{}'
+   *   },
+   *   subEnvironments: [
+   *     {
+   *       title: 'sub-1',
+   *       variablesJson: '{}'
+   *     }
+   *   ]
+   * }
+   */
+  initialEnvironments?: IInitialEnvironments;
 
   /**
    * Namespace for storing the data for the altair instance.
@@ -87,6 +105,7 @@ export class AltairConfig {
     variables: '',
     // Force type of header, since initial value inference is wrong
     headers: (null as unknown as IDictionary),
+    environments: ({} as IInitialEnvironments),
     preRequestScript: '',
     instanceStorageNamespace: '',
   };
@@ -95,6 +114,7 @@ export class AltairConfig {
     subscriptionsEndpoint,
     initialQuery,
     initialHeaders,
+    initialEnvironments,
     initialVariables,
     initialPreRequestScript,
     instanceStorageNamespace,
@@ -104,6 +124,7 @@ export class AltairConfig {
     this.initialData.query = (window as any).__ALTAIR_INITIAL_QUERY__ || initialQuery || '';
     this.initialData.variables = (window as any).__ALTAIR_INITIAL_VARIABLES__ || initialVariables || '';
     this.initialData.headers = (window as any).__ALTAIR_INITIAL_HEADERS__ || initialHeaders || '';
+    this.initialData.environments = (window as any).__ALTAIR_INITIAL_ENVIRONMENTS__ || initialEnvironments || {};
     this.initialData.preRequestScript = (window as any).__ALTAIR_INITIAL_PRE_REQUEST_SCRIPT__ || initialPreRequestScript || '';
     this.initialData.instanceStorageNamespace = (window as any).__ALTAIR_INSTANCE_STORAGE_NAMESPACE__ || instanceStorageNamespace || '';
   }

--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -1,6 +1,6 @@
 import isElectron from './utils/is_electron';
 import { IDictionary } from './interfaces/shared';
-import { State as IInitialEnvironments } from './reducers/environments';
+import { IInitialEnvironments } from './reducers/environments';
 
 const isTranslateMode = (window as any).__ALTAIR_TRANSLATE__;
 
@@ -45,12 +45,12 @@ export interface AltairConfigOptions {
    * {
    *   base: {
    *     title: 'Environment',
-   *     variablesJson: '{}'
+   *     variables: {}
    *   },
    *   subEnvironments: [
    *     {
    *       title: 'sub-1',
-   *       variablesJson: '{}'
+   *       variables: {}
    *     }
    *   ]
    * }
@@ -124,7 +124,7 @@ export class AltairConfig {
     this.initialData.query = (window as any).__ALTAIR_INITIAL_QUERY__ || initialQuery || '';
     this.initialData.variables = (window as any).__ALTAIR_INITIAL_VARIABLES__ || initialVariables || '';
     this.initialData.headers = (window as any).__ALTAIR_INITIAL_HEADERS__ || initialHeaders || '';
-    this.initialData.environments = (initialEnvironments || {}) as IInitialEnvironments;
+    this.initialData.environments = initialEnvironments || {};
     this.initialData.preRequestScript = (window as any).__ALTAIR_INITIAL_PRE_REQUEST_SCRIPT__ || initialPreRequestScript || '';
     this.initialData.instanceStorageNamespace = (window as any).__ALTAIR_INSTANCE_STORAGE_NAMESPACE__ || instanceStorageNamespace || '';
   }

--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -124,7 +124,7 @@ export class AltairConfig {
     this.initialData.query = (window as any).__ALTAIR_INITIAL_QUERY__ || initialQuery || '';
     this.initialData.variables = (window as any).__ALTAIR_INITIAL_VARIABLES__ || initialVariables || '';
     this.initialData.headers = (window as any).__ALTAIR_INITIAL_HEADERS__ || initialHeaders || '';
-    this.initialData.environments = (window as any).__ALTAIR_INITIAL_ENVIRONMENTS__ || initialEnvironments || {};
+    this.initialData.environments = (initialEnvironments || {}) as IInitialEnvironments;
     this.initialData.preRequestScript = (window as any).__ALTAIR_INITIAL_PRE_REQUEST_SCRIPT__ || initialPreRequestScript || '';
     this.initialData.instanceStorageNamespace = (window as any).__ALTAIR_INSTANCE_STORAGE_NAMESPACE__ || instanceStorageNamespace || '';
   }

--- a/src/app/reducers/environments.ts
+++ b/src/app/reducers/environments.ts
@@ -2,6 +2,18 @@ import { Action } from '@ngrx/store';
 import * as uuid from 'uuid/v4';
 import { getAltairConfig } from 'app/config';
 import * as environmentsAction from '../actions/environments/environments';
+import { IDictionary } from 'app/interfaces/shared';
+
+interface InitialEnvironmentState {
+  id?: string
+  title?: string,
+  variables?: IDictionary,
+};
+
+export interface IInitialEnvironments {
+  base?: InitialEnvironmentState,
+  subEnvironments?: InitialEnvironmentState[]
+}
 
 export interface EnvironmentState {
   // Adding undefined for backward compatibility
@@ -18,19 +30,23 @@ export interface State {
 }
 
 export const getInitialEnvironmentState = (): EnvironmentState => {
-  const { initialData } = getAltairConfig();
+  const { initialData: { environments } } = getAltairConfig();
+
   return {
-    title: 'Environment',
-    variablesJson: '{}',
-    ...initialData.environments.base
+    title: environments.base && environments.base.title || 'Environment',
+    variablesJson: JSON.stringify(environments.base && environments.base.variables || {}),
   };
 };
 
 const getInitialSubEnvironmentState = (): EnvironmentState[] => {
-  const { initialData } = getAltairConfig();
-  return (initialData.environments.subEnvironments || []).map(env => {
-    env.id = env.id || uuid();
-    return env;
+  const { initialData: { environments } } = getAltairConfig();
+
+  return (environments.subEnvironments || []).map((env, idx) => {
+    return {
+      id: env.id || uuid(),
+      title: env.title || `Environment ${idx + 1}`,
+      variablesJson: JSON.stringify(env.variables || {})
+    }
   });
 }
 

--- a/src/app/reducers/environments.ts
+++ b/src/app/reducers/environments.ts
@@ -22,7 +22,6 @@ export const getInitialEnvironmentState = (): EnvironmentState => {
   return {
     title: 'Environment',
     variablesJson: '{}',
-    id: uuid(),
     ...initialData.environments.base
   };
 };

--- a/src/app/reducers/environments.ts
+++ b/src/app/reducers/environments.ts
@@ -30,7 +30,7 @@ export const getInitialEnvironmentState = (): EnvironmentState => {
 const getInitialSubEnvironmentState = (): EnvironmentState[] => {
   const { initialData } = getAltairConfig();
   return (initialData.environments.subEnvironments || []).map(env => {
-    env.id = uuid();
+    env.id = env.id || uuid();
     return env;
   });
 }

--- a/src/app/reducers/environments.ts
+++ b/src/app/reducers/environments.ts
@@ -1,4 +1,5 @@
 import { Action } from '@ngrx/store';
+import * as uuid from 'uuid/v4';
 import { getAltairConfig } from 'app/config';
 import * as environmentsAction from '../actions/environments/environments';
 
@@ -21,13 +22,17 @@ export const getInitialEnvironmentState = (): EnvironmentState => {
   return {
     title: 'Environment',
     variablesJson: '{}',
+    id: uuid(),
     ...initialData.environments.base
   };
 };
 
 const getInitialSubEnvironmentState = (): EnvironmentState[] => {
   const { initialData } = getAltairConfig();
-  return initialData.environments.subEnvironments || [];
+  return (initialData.environments.subEnvironments || []).map(env => {
+    env.id = uuid();
+    return env;
+  });
 }
 
 export const getInitialState = (): State => {

--- a/src/app/reducers/environments.ts
+++ b/src/app/reducers/environments.ts
@@ -1,5 +1,5 @@
 import { Action } from '@ngrx/store';
-
+import { getAltairConfig } from 'app/config';
 import * as environmentsAction from '../actions/environments/environments';
 
 export interface EnvironmentState {
@@ -17,16 +17,23 @@ export interface State {
 }
 
 export const getInitialEnvironmentState = (): EnvironmentState => {
+  const { initialData } = getAltairConfig();
   return {
     title: 'Environment',
-    variablesJson: '{}'
+    variablesJson: '{}',
+    ...initialData.environments.base
   };
 };
 
+const getInitialSubEnvironmentState = (): EnvironmentState[] => {
+  const { initialData } = getAltairConfig();
+  return initialData.environments.subEnvironments || [];
+}
+
 export const getInitialState = (): State => {
   return {
-    base: { ...getInitialEnvironmentState() },
-    subEnvironments: [],
+    base: getInitialEnvironmentState(),
+    subEnvironments: getInitialSubEnvironmentState(),
   }
 };
 

--- a/src/app/reducers/windows.ts
+++ b/src/app/reducers/windows.ts
@@ -97,8 +97,7 @@ export function windows(reducer: ActionReducer<any>) {
                 return Object.assign({}, _state);
             default:
                 if (!_windowState) {
-                    // If the provided windowId is invalid, log the error and just return the state
-                    debug.warn('Invalid window ID provided.');
+                    // Just return state. The action was properly not for a PerWindow reducer
                     return _state;
                 }
 


### PR DESCRIPTION
### Fixes #1086 

### Checks

- [x] Ran `npm run test-build`

### Changes proposed in this pull request:

- Adds the ability to pass in `initialEnvironments` to AltairGraphQL.init()

Here's a sample config to test:

```js
document.addEventListener("DOMContentLoaded", () => {
  AltairGraphQL.init({
    initialEnvironments: {
      base: {
        title: "Base",
        variables: {
          "app-name": "altair-playground",
          "app-version": "1.0.0"
        }
      },
      subEnvironments: [
        {
          title: "Production",
          variables: {
            token: "ABC..."
          }
        },
        {
          title: "Staging",
          variables: {
            token: "XYZ..."
          }
        }
      ]
    }
  });
});
```
