### PR TITLE
Minor grammatical fix in 'Install Updates' message

### DIFF
--- a/packages/altair-electron/src/updates.js
+++ b/packages/altair-electron/src/updates.js
@@ -51,7 +51,7 @@ autoUpdater.on('update-not-available', () => {
 autoUpdater.on('update-downloaded', () => {
   dialog.showMessageBox({
     title: 'Install Updates',
-    message: 'Updates downloaded, application will be quit for update...'
+    message: 'Updates downloaded, application will now exit to update.'
   }, () => {
     setImmediate(() => autoUpdater.quitAndInstall());
   });


### PR DESCRIPTION
### Fixes #

Minor grammatical fix in 'Install Updates' message
![image](https://user-images.githubusercontent.com/10026538/71558933-37caa880-2a50-11ea-9514-4315d08e2a98.png)


### Checks

- [❌] Ran `npm run test-build`

I did this but it failed for some reason in `graphql-linter`.
I'm assuming this is not related to my very small change!
![image](https://user-images.githubusercontent.com/10026538/71559504-d6f29e80-2a56-11ea-86c9-dd16882242fc.png)

### Changes proposed in this pull request:

- Minor grammatical fix in 'Install Updates' message