### PR TITLE
Update PR template to use yarn instead of npm

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ### Checks
 
-- [ ] Ran `yarn run test-build`
+- [ ] Ran `yarn test-build`
 
 ### Changes proposed in this pull request:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ### Checks
 
-- [ ] Ran `npm run test-build`
+- [ ] Ran `yarn run test-build`
 
 ### Changes proposed in this pull request:
 


### PR DESCRIPTION
### Fixes #

Update PR template to use `yarn` instead of `npm`
To help prevent people like me using `npm install` instead of `yarn install` 😄 https://github.com/imolorhe/altair/pull/1140#issuecomment-569537366

### Checks

- [✔] Ran `yarn run test-build`
![image](https://user-images.githubusercontent.com/10026538/71562770-fdc3cb80-2a7c-11ea-83d4-69c3ba65dbef.png)
![image](https://user-images.githubusercontent.com/10026538/71562771-02887f80-2a7d-11ea-8a85-728c693442b2.png)

### Changes proposed in this pull request:

- Update PR template to use `yarn` instead of `npm`
