### PR TITLE
Fix the Koa docs for endpointURL

### DIFF
--- a/docs/docs/integrations/altair-express-middleware.md
+++ b/docs/docs/integrations/altair-express-middleware.md
@@ -3,16 +3,18 @@ parent: Integrations
 ---
 
 ## altair-express-middleware
+
 npm
 {: .label .label-red }
 Express
 {: .label .label-purple }
 
-You can use altair with an express server using [altair-express-middleware](https://www.npmjs.com/package/altair-express-middleware).
+You can use Altair with an Express server using [altair-express-middleware](https://www.npmjs.com/package/altair-express-middleware).
 
-This is an express middleware for mounting an instance of altair GraphQL client.
+This is an Express middleware for mounting an instance of Altair GraphQL client.
 
 #### Installation
+
 This is a node module and can be installed using npm:
 
 ```
@@ -36,12 +38,12 @@ import { schema } from './schema';
 
 const server = express();
 
-// Mount your graphQL server endpoint
+// Mount your GraphQL server endpoint
 server.use('/graphql', bodyParser.json(), graphqlExpress({
   schema
 }));
 
-// Mount your altair GraphQL client
+// Mount your Altair GraphQL client
 server.use('/altair', altairExpress({
   endpointURL: '/graphql',
   subscriptionsEndpoint: `ws://localhost:4000/subscriptions`,

--- a/docs/docs/integrations/altair-koa-middleware.md
+++ b/docs/docs/integrations/altair-koa-middleware.md
@@ -3,16 +3,18 @@ parent: Integrations
 ---
 
 ## altair-koa-middleware
+
 npm
 {: .label .label-red }
 Koa
 {: .label .label-purple }
 
-You can use altair with a koa server using [altair-koa-middleware](https://www.npmjs.com/package/altair-koa-middleware).
+You can use Altair with a Koa server using [altair-koa-middleware](https://www.npmjs.com/package/altair-koa-middleware).
 
-This is an koa middleware for mounting an instance of altair GraphQL client.
+This is an koa middleware for mounting an instance of Altair GraphQL client.
 
 #### Installation
+
 This is a node module and can be installed using npm:
 
 ```
@@ -38,7 +40,7 @@ createRouteExplorer({
   url: '/altair',
   router,
   opts: {
-    endpoint: '/graphql',
+    endpointURL: '/graphql',
     subscriptionsEndpoint: `ws://localhost:4000/subscriptions`,
     initialQuery: `{ getData { id name surname } }`,
   },

--- a/docs/docs/integrations/altair-static.md
+++ b/docs/docs/integrations/altair-static.md
@@ -3,6 +3,7 @@ parent: Integrations
 ---
 
 ## altair-static
+
 npm
 {: .label .label-red }
 
@@ -10,6 +11,7 @@ npm
 
 
 #### Installation
+
 This is a node module and can be installed using npm:
 
 ```

--- a/docs/docs/integrations/gatsby-plugin-altair-graphql.md
+++ b/docs/docs/integrations/gatsby-plugin-altair-graphql.md
@@ -3,6 +3,7 @@ parent: Integrations
 ---
 
 ## gatsby-plugin-altair-graphql
+
 npm
 {: .label .label-red }
 Gatsby
@@ -11,6 +12,7 @@ Gatsby
 [gatsby-plugin-altair-graphql](https://www.npmjs.com/package/gatsby-plugin-altair-graphql) adds an instance of [Altair GraphQL client](https://altair.sirmuel.design/) to [Gatsby](https://www.gatsbyjs.org/), discovered at `/__altair` route.
 
 #### Installation
+
 This is a node module and can be installed using npm:
 
 ```


### PR DESCRIPTION
### Fixes

The Koa docs incorrectly said the option was `endpoint` instead of `endpointURL`.

I also tidied up some of the surrounding grammar and formatting.

### Checks

- [ ] Ran `yarn test-build`

### Changes proposed in this pull request:

- Updated Koa docs.