### PR TITLE
Correct object handling in altair-static render function

### DIFF
--- a/packages/altair-static/src/__snapshots__/index.test.ts.snap
+++ b/packages/altair-static/src/__snapshots__/index.test.ts.snap
@@ -50,6 +50,7 @@ exports[`renderAltair should return expected string 1`] = `
             
             
             
+            
         };
         AltairGraphQL.init(altairOpts);
     </script></body>
@@ -68,9 +69,10 @@ exports[`renderInitialOptions should return expected string 1`] = `
       }\`,
             
             
+            initialHeaders: {\\"X-GraphQL-Token\\":\\"asd7-237s-2bdk-nsdk4\\"},
             
             
-            
+            initialSettings: {\\"theme\\":\\"dark\\"},
         };
         AltairGraphQL.init(altairOpts);
     "

--- a/packages/altair-static/src/index.test.ts
+++ b/packages/altair-static/src/index.test.ts
@@ -10,7 +10,13 @@ describe('renderInitialOptions', () => {
       initialQuery: `query {
         Hello
       }`,
-      endpointURL: 'https://example.com/graphql'
+      endpointURL: 'https://example.com/graphql',
+      initialHeaders: {
+        'X-GraphQL-Token': 'asd7-237s-2bdk-nsdk4'
+      },
+      initialSettings: {
+        theme: 'dark'
+      }
     });
     expect(result).toMatchSnapshot();
   });

--- a/packages/altair-static/src/index.ts
+++ b/packages/altair-static/src/index.ts
@@ -49,7 +49,7 @@ export interface RenderOptions {
      *  'X-GraphQL-Token': 'asd7-237s-2bdk-nsdk4'
      * }
      */
-    initialHeaders?: Object;
+    initialHeaders?: {[key: string]: string};
 
     /**
      * Whether to render the initial options in a seperate javascript file or not.
@@ -86,8 +86,12 @@ export interface RenderOptions {
 
     /**
      * Initial app settings to use
+     * @example
+     * {
+     *   theme: 'dark'
+     * }
      */
-    initialSettings?: any;
+    initialSettings?: {[key: string]: any};
 }
 
 /**
@@ -102,7 +106,8 @@ export const renderInitialOptions = ({
     initialHeaders,
     initialPreRequestScript,
     initialEnvironments,
-    instanceStorageNamespace
+    instanceStorageNamespace,
+    initialSettings
 }: RenderOptions = {}) => {
     return `
         const altairOpts = {
@@ -114,6 +119,7 @@ export const renderInitialOptions = ({
             ${getObjectPropertyForOption(initialHeaders, 'initialHeaders')}
             ${getObjectPropertyForOption(initialEnvironments, 'initialEnvironments')}
             ${getObjectPropertyForOption(instanceStorageNamespace, 'instanceStorageNamespace')}
+            ${getObjectPropertyForOption(initialSettings, 'initialSettings')}
         };
         AltairGraphQL.init(altairOpts);
     `;
@@ -140,12 +146,11 @@ export const renderAltair = (options: RenderOptions = {}) => {
 
 function getObjectPropertyForOption(option: any, propertyName: string) {
     if (option) {
-        let optionString = option;
         switch (typeof option) {
             case 'object':
-                optionString = JSON.stringify(option);
+              return `${propertyName}: ${JSON.stringify(option)},`;
         }
-        return `${propertyName}: \`${optionString}\`,`;
+        return `${propertyName}: \`${option}\`,`;
     }
     return '';
 }


### PR DESCRIPTION
### Fixes #1338

This fixes an issue with how **altair-static** rendered stringified JSON objects. It was incorrectly rendering JSON objects by surrounding the stringified object with template string quotes (\` ... \`):

> Expected: `initialHeaders: {\\"X-GraphQL-Token\\":\\"asd7-237s-2bdk-nsdk4\\"},`
> Actual ``initialHeaders: `{\\"X-GraphQL-Token\\":\\"asd7-237s-2bdk-nsdk4\\"}`,`` (notice unwanted backticks)

In addition to the above fix, this PR also includes the `initialSettings` in the rendering which was previously missing.

### Checks

- [x] Ran `yarn test-build`
- [x] Added `initialHeaders` and `initialSettings` options to test spec.
- [x] Tested `altair-koa-middleware` correctly rendered with `initialHeaders` and `initialSettings`.

### Changes proposed in this pull request:

- Fix **altair-static** JSON object rendering for injected script tag.
- Add `initialSettings` option to init options in **altair-static**.
