### PR TITLE
Fix small text inconsistency in the settings panel

### DIFF
--- a/docs/docs/features/settings-pane.md
+++ b/docs/docs/features/settings-pane.md
@@ -41,7 +41,7 @@ Any valid CSS font family combinations can be used here.
 ### `disablePushNotification` - Specifies if native push notifications should be disabled
 _Default: false_
 
-### `enableExperimental` - Enable experimental features in Altair. Note: The features might be unstable.
+### `enableExperimental` - Enable experimental features in Altair. Note: The features might be unstable
 _Default: false_
 
 ### `alert.disableWarnings` - Disable warning alerts

--- a/packages/altair-app/src/app/store/settings/settings.reducer.ts
+++ b/packages/altair-app/src/app/store/settings/settings.reducer.ts
@@ -31,7 +31,7 @@ export interface State {
 
   /**
    * Enable experimental features in Altair.
-   * Note: The features might be unstable.
+   * Note: The features might be unstable
    */
   enableExperimental?: boolean;
 

--- a/packages/altair-app/src/app/utils/settings.schema.json
+++ b/packages/altair-app/src/app/utils/settings.schema.json
@@ -46,7 +46,7 @@
             "type": "boolean"
         },
         "enableExperimental": {
-            "description": "Enable experimental features in Altair.\nNote: The features might be unstable.",
+            "description": "Enable experimental features in Altair.\nNote: The features might be unstable",
             "type": "boolean"
         },
         "historyDepth": {

--- a/packages/altair-app/src/app/utils/validate_settings_schema.js
+++ b/packages/altair-app/src/app/utils/validate_settings_schema.js
@@ -404,7 +404,7 @@ validate.schema = {
       "type": "boolean"
     },
     "enableExperimental": {
-      "description": "Enable experimental features in Altair.\nNote: The features might be unstable.",
+      "description": "Enable experimental features in Altair.\nNote: The features might be unstable",
       "type": "boolean"
     },
     "historyDepth": {


### PR DESCRIPTION
### Fixes #

This is a very small change. When I used this for the first time I noticed that all settings descriptions ended in a period except for one. So this PR removes the period from the one that has it.

Before
<img width="564" alt="Screen Shot 2020-09-14 at 8 48 01 AM" src="https://user-images.githubusercontent.com/1654201/93028508-7b118980-f668-11ea-977c-324c6cb1f980.png">

After
<img width="568" alt="Screen Shot 2020-09-14 at 8 46 56 AM" src="https://user-images.githubusercontent.com/1654201/93028517-81a00100-f668-11ea-9a2c-4730b3d0b730.png">

### Checks

- [x] Ran `yarn test-build`

### Changes proposed in this pull request:

- Change settings description text
