### PR TITLE
Add the Amazon Cognito user pools and OpenID Connect support for AWS AppSync Subscription

### DIFF
--- a/docs/docs/features/graphql-subscriptions.md
+++ b/docs/docs/features/graphql-subscriptions.md
@@ -21,7 +21,7 @@ This supports the MQTT-based subscription protocol used in [AWS AppSync](https:/
 The connection parameters are in JSON format as following
 
     {
-      "aws_project_region": "<AWS_REGION>", //AWS Region
+      "aws_project_region": "<AWS_REGION>", //AWS Region abbreviation
       "aws_appsync_graphQlEndpoint": "https://******", //The value you can copy from AWS AppSync Endpoint, please use the HTTPS value
       "aws_appsync_region": "<AWS_REGION>", //AWS Region abbreviation
       "aws_appsync_authenicationType": "<AWS_APPYSYNC_Authenication_TYPE>", //API_KEY, OPENID_CONNECT or AMAZON_COGNITO_USER_POOLS (IAM is not supported)

--- a/docs/docs/features/graphql-subscriptions.md
+++ b/docs/docs/features/graphql-subscriptions.md
@@ -18,6 +18,17 @@ This supports the [GraphQL over websocket](https://github.com/enisdenjo/graphql-
 
 This supports the MQTT-based subscription protocol used in [AWS AppSync](https://docs.aws.amazon.com/appsync/latest/devguide/welcome.html) which is an enterprise-level, fully managed GraphQL service with real-time data synchronization and offline programming features.
 
+The connection parameters are in JSON format as following
+
+    {
+      "aws_project_region": "<AWS_REGION>", //AWS Region
+      "aws_appsync_graphQlEndpoint": "https://******", //The value you can copy from AWS AppSync Endpoint, please use the HTTPS value
+      "aws_appsync_region": "<AWS_REGION>", //AWS Region abbreviation
+      "aws_appsync_authenicationType": "<AWS_APPYSYNC_Authenication_TYPE>", //API_KEY, OPENID_CONNECT or AMAZON_COGNITO_USER_POOLS (IAM is not supported)
+      "aws_appsync_apiKey": "*******", //API Key, required if authenication type = API_KEY,
+      "aws_appsync_jwtToken": "******", //JWT Token, required if authenication type = OPENID_CONNECT or AMAZON_COGNITO_USER_POOLS
+    }
+
 ![Specifying connection parameters](https://user-images.githubusercontent.com/15103463/99538456-49d97080-29ad-11eb-9002-e744eec42780.png)
 
 ![AWS AppSync subscription](https://i.imgur.com/pDhCiBn.png)

--- a/packages/altair-app/src/app/services/subscriptions/providers/app-sync.ts
+++ b/packages/altair-app/src/app/services/subscriptions/providers/app-sync.ts
@@ -2,7 +2,7 @@ import { SubscriptionProvider, SubscriptionProviderExecuteOptions } from '../sub
 import { Observable, of } from 'rxjs';
 import { createAuthLink } from 'aws-appsync-auth-link';
 import { createSubscriptionHandshakeLink } from 'aws-appsync-subscription-link';
-import { ApolloClient, ApolloLink, InMemoryCache, createHttpLink } from '@apollo/client/core';
+import { ApolloClient, ApolloLink, InMemoryCache } from '@apollo/client/core';
 import { parse } from 'graphql';
 
 export class AppSyncSubscriptionProvider extends SubscriptionProvider {
@@ -28,11 +28,9 @@ export class AppSyncSubscriptionProvider extends SubscriptionProvider {
       ...this.connectionParams.aws_appsync_jwtToken ? { jwtToken: this.connectionParams.aws_appsync_jwtToken } : {},
     };
 
-    const httpLink = createHttpLink({ uri: url });
-
     const link = ApolloLink.from([
       createAuthLink({ url, region, auth }),
-      createSubscriptionHandshakeLink(url, httpLink),
+      createSubscriptionHandshakeLink({ url, region, auth }),
     ]);
 
     const client = new ApolloClient({

--- a/packages/altair-app/src/app/services/subscriptions/providers/app-sync.ts
+++ b/packages/altair-app/src/app/services/subscriptions/providers/app-sync.ts
@@ -24,8 +24,8 @@ export class AppSyncSubscriptionProvider extends SubscriptionProvider {
     const region = this.connectionParams.aws_appsync_region;
     const auth = {
       type: this.connectionParams.aws_appsync_authenticationType,
-      ...this.connectionParams.aws_appsync_apiKey ? {apiKey: this.connectionParams.aws_appsync_apiKey} : {},
-      ...this.connectionParams.aws_appsync_jwtToken ? { jwtToken: this.connectionParams.aws_appsync_jwtToken } : {},
+      apiKey: this.connectionParams.aws_appsync_apiKey,
+      jwtToken: this.connectionParams.aws_appsync_jwtToken,
     };
 
     const link = ApolloLink.from([

--- a/packages/altair-app/src/app/services/subscriptions/providers/app-sync.ts
+++ b/packages/altair-app/src/app/services/subscriptions/providers/app-sync.ts
@@ -15,6 +15,7 @@ export class AppSyncSubscriptionProvider extends SubscriptionProvider {
     "aws_appsync_region": "us-west-2",
     "aws_appsync_authenticationType": "API_KEY",
     "aws_appsync_apiKey": "..."
+    "aws_appsync_jwtToken" "..."
   }
    */
 
@@ -23,7 +24,8 @@ export class AppSyncSubscriptionProvider extends SubscriptionProvider {
     const region = this.connectionParams.aws_appsync_region;
     const auth = {
       type: this.connectionParams.aws_appsync_authenticationType,
-      apiKey: this.connectionParams.aws_appsync_apiKey,
+      ...this.connectionParams.aws_appsync_apiKey ? {apiKey: this.connectionParams.aws_appsync_apiKey} : {},
+      ...this.connectionParams.aws_appsync_jwtToken ? { jwtToken: this.connectionParams.aws_appsync_jwtToken } : {},
     };
 
     const httpLink = createHttpLink({ uri: url });

--- a/packages/altair-app/src/app/services/subscriptions/providers/app-sync.ts
+++ b/packages/altair-app/src/app/services/subscriptions/providers/app-sync.ts
@@ -1,5 +1,5 @@
 import { SubscriptionProvider, SubscriptionProviderExecuteOptions } from '../subscription-provider';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { createAuthLink } from 'aws-appsync-auth-link';
 import { createSubscriptionHandshakeLink } from 'aws-appsync-subscription-link';
 import { ApolloClient, ApolloLink, InMemoryCache } from '@apollo/client/core';


### PR DESCRIPTION
### Fixes 
#1432 - Add the Amazon Cognito user pools and OpenID Connect support for AWS AppSync Subscription

### Checks

- [X] Ran `yarn test-build`

### Changes proposed in this pull request:
- Add the aws_appsync_jwtToken support
- Allow setting aws_appsync_apiKey conditionally
- Update the code to use appSync 3+ style (https://github.com/awslabs/aws-mobile-appsync-sdk-js#using-authorization-and-subscription-links-with-apollo-client-no-offline-support)
