### PR TITLE
add initialSubscriptionsProvider config

### DIFF
--- a/.changeset/shiny-bobcats-attack.md
+++ b/.changeset/shiny-bobcats-attack.md
@@ -1,0 +1,6 @@
+---
+"altair-app": patch
+"altair-static": patch
+---
+
+add initialSubscriptionsProvider config

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ $ composer require xkojimedia/laravel-altair-graphql
 *You can find other available integrations here: https://altair.sirmuel.design/docs/integrations*
 
 ### Configuration Options
-When using a custom instance of Altair, there are [couple of options](https://github.com/imolorhe/altair/blob/staging/packages/altair-app/src/app/config.ts#L9) you can use to customize Altair based on your needs:
+When using a custom instance of Altair, there are [couple of options](https://github.com/imolorhe/altair/blob/staging/packages/altair-app/src/app/modules/altair/config.ts#L9) you can use to customize Altair based on your needs:
 
 - `endpointURL` `string` - URL to set as the server endpoint
 - `subscriptionsEndpoint` `string` - URL to set as the subscription endpoint

--- a/README.md
+++ b/README.md
@@ -122,10 +122,11 @@ $ composer require xkojimedia/laravel-altair-graphql
 *You can find other available integrations here: https://altair.sirmuel.design/docs/integrations*
 
 ### Configuration Options
-When using a custom instance of Altair, there are [couple of options](https://github.com/imolorhe/altair/blob/staging/packages/altair-app/src/app/config.ts#L7) you can use to customize Altair based on your needs:
+When using a custom instance of Altair, there are [couple of options](https://github.com/imolorhe/altair/blob/staging/packages/altair-app/src/app/config.ts#L9) you can use to customize Altair based on your needs:
 
 - `endpointURL` `string` - URL to set as the server endpoint
 - `subscriptionsEndpoint` `string` - URL to set as the subscription endpoint
+- `initialSubscriptionsProvider` `"websocket" | "graphql-ws" | "app-sync" | "action-cable"` - Initial subscriptions provider
 - `initialQuery` `string` - Initial query to be added
 - `initialVariables` `string` - Initial variables to be added (in JSON format) e.g. `'{ "var1": "first variable" }'`
 - `initialPreRequestScript` `string` - Initial pre-request script to be added e.g. `'altair.helpers.getEnvironment("api_key")'`

--- a/packages/altair-app/src/app/modules/altair/config.ts
+++ b/packages/altair-app/src/app/modules/altair/config.ts
@@ -2,6 +2,7 @@ import isElectron from './utils/is_electron';
 import { IDictionary } from './interfaces/shared';
 import { IInitialEnvironments } from './store/environments/environments.reducer';
 import * as fromSettings from './store/settings/settings.reducer';
+import { SubscriptionProviderIds, WEBSOCKET_PROVIDER_ID } from "./services/subscriptions/subscription-provider-registry.service";
 
 const isTranslateMode = (window as any).__ALTAIR_TRANSLATE__;
 
@@ -75,6 +76,13 @@ export interface AltairConfigOptions {
    * Initial app settings to use
    */
   initialSettings?: Partial<fromSettings.State>;
+
+  /**
+   * Initial subscriptions provider
+   *
+   * @default "websocket"
+   */
+  initialSubscriptionsProvider?: SubscriptionProviderIds;
 }
 
 export class AltairConfig {
@@ -122,6 +130,7 @@ export class AltairConfig {
     postRequestScript: '',
     instanceStorageNamespace: 'altair_',
     settings: (undefined as unknown as AltairConfigOptions['initialSettings']),
+    initialSubscriptionsProvider: undefined as AltairConfigOptions['initialSubscriptionsProvider']
   };
   constructor({
     endpointURL,
@@ -134,6 +143,7 @@ export class AltairConfig {
     initialPostRequestScript = '',
     instanceStorageNamespace,
     initialSettings,
+    initialSubscriptionsProvider
   }: AltairConfigOptions = {}) {
     this.initialData.url = (window as any).__ALTAIR_ENDPOINT_URL__ || endpointURL || '';
     this.initialData.subscriptionsEndpoint = (window as any).__ALTAIR_SUBSCRIPTIONS_ENDPOINT__ || subscriptionsEndpoint || '';
@@ -145,6 +155,7 @@ export class AltairConfig {
     this.initialData.postRequestScript = initialPostRequestScript;
     this.initialData.instanceStorageNamespace = (window as any).__ALTAIR_INSTANCE_STORAGE_NAMESPACE__ || instanceStorageNamespace || 'altair_';
     this.initialData.settings = initialSettings || undefined;
+    this.initialData.initialSubscriptionsProvider = initialSubscriptionsProvider || WEBSOCKET_PROVIDER_ID;
   }
 }
 

--- a/packages/altair-app/src/app/modules/altair/config.ts
+++ b/packages/altair-app/src/app/modules/altair/config.ts
@@ -2,7 +2,7 @@ import isElectron from './utils/is_electron';
 import { IDictionary } from './interfaces/shared';
 import { IInitialEnvironments } from './store/environments/environments.reducer';
 import * as fromSettings from './store/settings/settings.reducer';
-import { SubscriptionProviderIds, WEBSOCKET_PROVIDER_ID } from "./services/subscriptions/subscription-provider-registry.service";
+import { SubscriptionProviderIds, WEBSOCKET_PROVIDER_ID } from './services/subscriptions/subscription-provider-registry.service';
 
 const isTranslateMode = (window as any).__ALTAIR_TRANSLATE__;
 

--- a/packages/altair-app/src/app/modules/altair/services/subscriptions/subscription-provider-registry.service.ts
+++ b/packages/altair-app/src/app/modules/altair/services/subscriptions/subscription-provider-registry.service.ts
@@ -12,6 +12,15 @@ export const GRAPHQL_WS_PROVIDER_ID = 'graphql-ws';
 export const APP_SYNC_PROVIDER_ID = 'app-sync';
 export const ACTION_CABLE_PROVIDER_ID = 'action-cable';
 
+export const SUBSCRIPTION_PROVIDER_IDS = {
+  WEBSOCKET: WEBSOCKET_PROVIDER_ID,
+  GRAPHQL_WS: GRAPHQL_WS_PROVIDER_ID,
+  APP_SYNC: APP_SYNC_PROVIDER_ID,
+  ACTION_CABLE: ACTION_CABLE_PROVIDER_ID
+} as const;
+
+export type SubscriptionProviderIds = typeof SUBSCRIPTION_PROVIDER_IDS[keyof typeof SUBSCRIPTION_PROVIDER_IDS];
+
 @Injectable()
 export class SubscriptionProviderRegistryService {
   private list: SubscriptionProviderData[] = [];

--- a/packages/altair-app/src/app/modules/altair/store/query/query.reducer.ts
+++ b/packages/altair-app/src/app/modules/altair/store/query/query.reducer.ts
@@ -74,7 +74,7 @@ export const getInitialState = (): State => {
     editorAlertSuccess: true,
     subscriptionClient: null,
     subscriptionConnectionParams: '{}',
-    subscriptionProviderId: WEBSOCKET_PROVIDER_ID,
+    subscriptionProviderId: altairConfig.initialData.initialSubscriptionsProvider || WEBSOCKET_PROVIDER_ID,
     isSubscribed: false,
     subscriptionResponseList: [],
     autoscrollSubscriptionResponse: false,

--- a/packages/altair-static/src/__snapshots__/index.test.ts.snap
+++ b/packages/altair-static/src/__snapshots__/index.test.ts.snap
@@ -51,6 +51,7 @@ exports[`renderAltair should return expected string 1`] = `
             
             
             
+            
         };
         AltairGraphQL.init(altairOpts);
     </script></body>
@@ -73,6 +74,7 @@ exports[`renderInitialOptions should return expected string 1`] = `
             
             
             initialSettings: {\\"theme\\":\\"dark\\"},
+            
         };
         AltairGraphQL.init(altairOpts);
     "

--- a/packages/altair-static/src/index.ts
+++ b/packages/altair-static/src/index.ts
@@ -92,6 +92,14 @@ export interface RenderOptions {
      * }
      */
     initialSettings?: {[key: string]: any};
+
+    /**
+     * Initial subscription provider
+     *
+     * @default "websocket"
+     */
+    initialSubscriptionsProvider?:
+      "websocket" | "graphql-ws" | "app-sync" | "action-cable"
 }
 
 /**
@@ -107,7 +115,8 @@ export const renderInitialOptions = ({
     initialPreRequestScript,
     initialEnvironments,
     instanceStorageNamespace,
-    initialSettings
+    initialSettings,
+    initialSubscriptionsProvider
 }: RenderOptions = {}) => {
     return `
         const altairOpts = {
@@ -120,6 +129,7 @@ export const renderInitialOptions = ({
             ${getObjectPropertyForOption(initialEnvironments, 'initialEnvironments')}
             ${getObjectPropertyForOption(instanceStorageNamespace, 'instanceStorageNamespace')}
             ${getObjectPropertyForOption(initialSettings, 'initialSettings')}
+            ${getObjectPropertyForOption(initialSubscriptionsProvider, 'initialSubscriptionsProvider')}
         };
         AltairGraphQL.init(altairOpts);
     `;


### PR DESCRIPTION
### Checks

- [x] Ran `yarn test-build`
- [x] Updated relevant documentations

If there is any documentation to be updated for this, I will do it, I've been using altair all this time just with type definitions.

### Changes proposed in this pull request:

Add the possibility of setting the initial config for the subscriptions provider, since with the new graphql-ws integration, in some new projects I'm working on, graphql-ws is going to be the default.
