### PR TITLE
exclude js from exported types

### DIFF
--- a/packages/altair-exported-types/package.json
+++ b/packages/altair-exported-types/package.json
@@ -10,9 +10,7 @@
   },
   "devDependencies": {
     "jest": "^26.6.3",
-    "typescript": "4.0.7"
-  },
-  "dependencies": {
+    "typescript": "4.0.7",
     "uuid": "3.4.0"
   }
 }

--- a/packages/altair-exported-types/tsconfig.json
+++ b/packages/altair-exported-types/tsconfig.json
@@ -16,6 +16,7 @@
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     "declarationMap": false,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "emitDeclarationOnly": true,
     "sourceMap": false,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist",                        /* Redirect output structure to the directory. */


### PR DESCRIPTION
### Fixes #

fixes #1607 

### Checks

- [ ] Ran `yarn test-build` | not relevant
- [ ] Updated relevant documentations | not relevant
- [ ] Updated matching config options in altair-static | not relevant

### Changes proposed in this pull request:

exclude javascript and uuid dependency from altair-exported-types